### PR TITLE
Added MIT License link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,5 +208,5 @@ Gemini fallback uses a lighter summarization prompt (can be tuned for more detai
 📬 Contact & Contributions
 Want to try it out or contribute? DM me on [LinkedIn](https://www.linkedin.com/in/yogesh-kumar-299298260/) or open an issue!
 
-📄 License
-MIT © Yogesh Kumar
+## 📄 License  
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
✅ Pull Request: Added MIT License link to README

🔗 Related Issue: #41 

👤 Username: @vinitjain2005

📄 Summary
Added a direct link to the MIT License in the README.md.

Ensures users can easily access full license terms.

🛠️ Changes Made
Updated the 📄 License section:

📄 License  
This project is licensed under the [MIT License](LICENSE).

🔍 Checklist
Created a new branch: add-license-link-readme
Committed with message: Added MIT License link to README
Pushed to origin and opened PR
References issue #41 correctly

Screenshot:
<img width="834" height="182" alt="Screenshot 2025-08-06 174853" src="https://github.com/user-attachments/assets/bb595449-f914-4cbd-b82f-7c7bc66e49f0" />
