### PR TITLE
Add vercel.json to handle client-side routing (React Router)

### DIFF
--- a/src/vercel.json
+++ b/src/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
🔗 Related Issue

Closes  #65  (Fixes 404 errors on /privacy, /terms, and other client-side routes)

🎯 Rationale

Direct navigation to /privacy or /terms on production resulted in 404 NOT_FOUND errors because Vercel tried to resolve them as static files.
This change ensures all unmatched routes are served via index.html, allowing React Router to handle routing on the client side.

📝 Summary of Changes

Added vercel.json at project root to define a rewrite rule.

Ensures all non-static routes fall back to / (index.html).

<img width="1871" height="961" alt="image" src="https://github.com/user-attachments/assets/00cc9412-56fd-4b1e-ae86-43a53aef6335" />

Test Details

Navigated directly to /privacy → Privacy page renders successfully.
Navigated directly to /terms → Terms page renders successfully.
In-app navigation also works as expected.


✅ Users can now access /privacy and /terms directly without hitting a 404.

No UI changes.

Backend/API Changes
None.

📋 Checklist
Code Quality
 Code follows project style guidelines
 Self-review completed
 
Security & Performance
 No sensitive information exposed
 Performance impact considered
 Security implications reviewed

🚀 Deployment Notes
No database migrations required.

Ensure vercel.json is included in the root of the deployment branch.